### PR TITLE
fix issues while installing VirtualBox v5.2 on new Centos7 host

### DIFF
--- a/tasks/virtualbox.yml
+++ b/tasks/virtualbox.yml
@@ -67,10 +67,10 @@
     /usr/lib/virtualbox/vboxdrv.sh setup
     args:
       executable: /bin/bash
+      become: True
   when: virtualbox_installed.changed
   register: virtualbox_vboxdrv
   ignore_errors: False
-  become: True
 
 - name: Check if extension pack is already installed
   shell: "VBoxManage list extpacks"

--- a/tasks/virtualbox.yml
+++ b/tasks/virtualbox.yml
@@ -13,6 +13,7 @@
     - kernel-headers
     - kernel-devel
     - dkms
+    - wget
 
 - name: add virtualbox repository
   copy:
@@ -68,20 +69,22 @@
       executable: /bin/bash
   when: virtualbox_installed.changed
   register: virtualbox_vboxdrv
-  ignore_errors: True
+  ignore_errors: False
+  become: True
 
 - name: Check if extension pack is already installed
   shell: "VBoxManage list extpacks"
   register: virtualbox_extpack_list
 
 - name: Download VirtualBox extension pack
-  shell: "cd /tmp/ &&  wget http://download.virtualbox.org/virtualbox/{{virtualbox_version}}.2/Oracle_VM_VirtualBox_Extension_Pack-{{virtualbox_version}}.28.vbox-extpack"
+  shell: "cd /tmp/ &&  wget http://download.virtualbox.org/virtualbox/{{virtualbox_version}}.2/Oracle_VM_VirtualBox_Extension_Pack-{{virtualbox_version}}.2.vbox-extpack"
   when: 'virtualbox_extpack_list.stdout == "Extension Packs: 0"'
 
 - name: Install VirtualBox extension pack
-  shell: "VBoxManage extpack install --replace /tmp/Oracle_VM_VirtualBox_Extension_Pack-{{virtualbox_version}}.28.vbox-extpack"
+  shell: "printf 'y\n'|VBoxManage extpack install --replace /tmp/Oracle_VM_VirtualBox_Extension_Pack-{{virtualbox_version}}.2.vbox-extpack"
   when: 'virtualbox_extpack_list.stdout == "Extension Packs: 0"'
+  become: True
 
-- name: failed to install VritualBox
-  fail: msg="failed to install VritualBox"
+- name: failed to install VirtualBox
+  fail: msg="failed to install VirtualBox"
   when: ((virtualbox_vboxdrv|failed) and (virtualbox_role_debug|bool == false))


### PR DESCRIPTION
this PR fixes issues that arose while installing VirtualBox 5.2 on a freshly installed Centos7 host.

playbook:
```
---
- hosts: virtualbox
  roles:
    - { role: escapace.virtualbox, virtualbox_version: '5.2' }
```


changelog:
- fix unattended install of Extension-Pack
- fix wget url for default VirtualBox 5.2 install
- fix wget dependency issue
- fix permission issue while installing kernel module
- fix typo